### PR TITLE
Add `trancated` property to `DTCoreTextLayoutFrame`

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.h
+++ b/Core/Source/DTCoreTextLayoutFrame.h
@@ -120,6 +120,11 @@ typedef NS_ENUM(NSUInteger, DTCoreTextLayoutFrameDrawingOptions)
  */
 - (NSArray *)stringIndices;
 
+/**
+ Indicates whether the text was truncated to fit `frame` and `numberOfLines` constraints.
+ */
+@property (nonatomic, assign, readonly, getter=isTruncated) BOOL truncated;
+
 
 /**
  The frame rectangle for the layout frame.

--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -37,6 +37,8 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	DTCoreTextLayoutFrameTextBlockHandler _textBlockHandler;
 	
 	CGFloat _longestLayoutLineWidth;
+
+	BOOL _truncated;
 }
 
 // makes a frame for a specific part of the attributed string of the layouter
@@ -437,7 +439,10 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	NSUInteger maxIndex = NSMaxRange(_requestedStringRange);
 	NSUInteger fittingLength = 0;
 	BOOL shouldTruncateLine = NO;
-	
+
+	// reset `_truncated` flag
+	_truncated = NO;
+
 	do  // for each line
 	{
 		while (lineRange.location >= (currentParagraphRange.location+currentParagraphRange.length))
@@ -542,6 +547,9 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
         }
 		else
 		{
+			// memorize that there is a truncated line
+			_truncated = YES;
+
 			// extend the line to the end of the current paragraph
 			// if we extend to the entire to the entire text range
 			// it is possible to pull lines up from paragraphs below us
@@ -1666,6 +1674,15 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	}
 	
 	return array;
+}
+
+- (BOOL)isTruncated {
+	if (!_lines)
+	{
+		[self _buildLines];
+	}
+
+	return _truncated;
 }
 
 - (NSInteger)lineIndexForGlyphIndex:(NSInteger)index


### PR DESCRIPTION
There is no other way to get to know whether text is truncated due to the `numberOfLines` constraint