### PR TITLE
Redraw text on iOS 15

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -109,6 +109,7 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)setup
 {
+	self.layer.needsDisplayOnBoundsChange = YES;
 	self.contentMode = UIViewContentModeTopLeft; // to avoid bitmap scaling effect on resize
 	_shouldLayoutCustomSubviews = YES;
 	

--- a/Core/Source/DTLinkButton.m
+++ b/Core/Source/DTLinkButton.m
@@ -37,7 +37,8 @@ NSString *DTLinkButtonDidHighlightNotification = @"DTLinkButtonDidHighlightNotif
 		self.userInteractionEnabled = YES;
 		self.enabled = YES;
 		self.opaque = NO;
-		
+		self.layer.needsDisplayOnBoundsChange = YES;
+
 		_showsTouchWhenHighlighted = YES;
 		
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(highlightNotification:) name:DTLinkButtonDidHighlightNotification object:nil];


### PR DESCRIPTION
На iOS 15 в некоторых случаях не отрисовывался текст в `DTAttributedLabel` и `DTLinkLabel`. Может быть можно было поправить отрисовку более эффективно, инвалидируя отдельные области (`setNeedsDisplayInRect:`), но я предпочел сделать более гарантированный/надежный, да и более простой, фикс.