### PR TITLE
Redraw text on iOS 15

### DIFF
--- a/Core/Source/DTAttributedTextContentView.m
+++ b/Core/Source/DTAttributedTextContentView.m
@@ -109,8 +109,8 @@ static Class _layerClassToUseForDTAttributedTextContentView = nil;
 
 - (void)setup
 {
-	self.layer.needsDisplayOnBoundsChange = YES;
 	self.contentMode = UIViewContentModeTopLeft; // to avoid bitmap scaling effect on resize
+	self.layer.needsDisplayOnBoundsChange = YES;
 	_shouldLayoutCustomSubviews = YES;
 	
 	// no extra leading is added by default


### PR DESCRIPTION
Исправил порядок вызовов. Setter `contentMode` сбрасывает значение `layer.needsDisplayOnBoundsChange`, поэтому `layer.needsDisplayOnBoundsChange` надо выставлять после `contentMode`.