### PR TITLE
Fix label width calculation

### DIFF
--- a/Core/Source/DTCoreTextLayoutFrame.m
+++ b/Core/Source/DTCoreTextLayoutFrame.m
@@ -1747,15 +1747,16 @@ static BOOL _DTCoreTextLayoutFramesShouldDrawDebugFrames = NO;
 	if (_frame.size.width == CGFLOAT_WIDTH_UNKNOWN)
 	{
 		// actual frame width is maximum value of lines
-		CGFloat maxWidth = 0;
-		
+		CGFloat minX = 0;
+		CGFloat maxX = 0;
+
 		for (DTCoreTextLayoutLine *oneLine in _lines)
 		{
-			CGFloat lineWidthFromFrameOrigin = CGRectGetMaxX(oneLine.frame) - _frame.origin.x;
-			maxWidth = MAX(maxWidth, lineWidthFromFrameOrigin);
+			minX = MIN(minX, CGRectGetMinX(oneLine.frame));
+			maxX = MAX(maxX, CGRectGetMaxX(oneLine.frame));
 		}
 		
-		_frame.size.width = ceil(maxWidth);
+		_frame.size.width = ceil(maxX - minX);
 	}
 	
 	return _frame;


### PR DESCRIPTION
In `DTCoreTextLayoutFrame`, there is a bug in frame width calculation. When the initial `frame.width` is `CGFLOAT_WIDTH_UNKNOWN` *and* the text is centered (`DTDefaultTextAlignment` is `.center`), the calculated `frame.width` is about half of the value of `CGFLOAT_WIDTH_UNKNOWN` (`CGFLOAT_WIDTH_UNKNOWN` is equal to 16777215).

I failed to run unit tests in DTCoreText. But anyway, the existing implementation was unacceptable, and the new one fits our needs in Joom.